### PR TITLE
Default missing files to use normal gf (and hence don't force the 'gf' mapping on users.

### DIFF
--- a/autoload/node.vim
+++ b/autoload/node.vim
@@ -3,25 +3,24 @@ let node#filetypes = ["javascript", "json"]
 
 function! node#initialize(root)
 	let b:node_root = a:root
-	call s:initializeCommands()
 	if index(g:node#filetypes, &ft) > -1 | call s:initializeJavaScript() | en
 	silent doautocmd User Node
 endfunction
 
-function! s:initializeCommands()
+function! node#initializeCommands()
 	command! -bar -bang -nargs=1 -buffer -complete=customlist,s:complete Nedit
 		\ exe s:nedit(<q-args>, bufname("%"), "edit<bang>")
 	command! -bar -bang -nargs=1 -buffer -complete=customlist,s:complete Nopen
 		\ exe s:nopen(<q-args>, bufname("%"), "edit<bang>")
 
-	nnoremap <buffer><silent> <Plug>NodeGotoFile
-		\ :call <SID>edit(expand("<cfile>"), bufname("%"))<CR>
-	nnoremap <buffer><silent> <Plug>NodeSplitGotoFile
-		\ :call <SID>edit(expand("<cfile>"), bufname("%"), "split")<CR>
-	nnoremap <buffer><silent> <Plug>NodeVSplitGotoFile
-		\ :call <SID>edit(expand("<cfile>"), bufname("%"), "vsplit")<CR>
-	nnoremap <buffer><silent> <Plug>NodeTabGotoFile
-		\ :call <SID>edit(expand("<cfile>"), bufname("%"), "tab split")<CR>
+	command! -nargs=0 -complete=customlist,s:complete NodeGotoFile
+		\ :call <SID>edit(expand("<cfile>"), bufname("%"))
+	command! -nargs=0 -complete=customlist,s:complete NodeSplitGotoFile
+		\ :call <SID>edit(expand("<cfile>"), bufname("%"), "split")
+	command! -nargs=0 -complete=customlist,s:complete NodeVSplitGotoFile
+		\ :call <SID>edit(expand("<cfile>"), bufname("%"), "vsplit")
+	command! -nargs=0 -complete=customlist,s:complete NodeTabGotoFile
+		\ :call <SID>edit(expand("<cfile>"), bufname("%"), "tab split")
 endfunction
 
 function! s:initializeJavaScript()
@@ -29,15 +28,6 @@ function! s:initializeJavaScript()
 	let &l:suffixesadd .= "," . join(g:node#suffixesadd, ",")
 	let &l:include = '\<require(\(["'']\)\zs[^\1]\+\ze\1'
 	let &l:includeexpr = "node#lib#find(v:fname, bufname('%'))"
-
-	if !hasmapto("<Plug>NodeGotoFile")
-		" Split gotofiles don't take a count for the new window's width, but for
-		" opening the nth file. Though Node.vim doesn't support counts atm.
-		nmap <buffer> gf <Plug>NodeGotoFile
-		nmap <buffer> <C-w>f <Plug>NodeSplitGotoFile
-		nmap <buffer> <C-w><C-f> <Plug>NodeSplitGotoFile
-		nmap <buffer> <C-w>gf <Plug>NodeTabGotoFile
-	endif
 endfunction
 
 function! s:edit(name, from, ...)

--- a/plugin/node.vim
+++ b/plugin/node.vim
@@ -10,6 +10,7 @@ function! s:detect(path)
 		let is_node = is_node || filereadable(path . "/package.json")
 		let is_node = is_node || isdirectory(path . "/node_modules")
 		if is_node | return node#initialize(path) | endif
+		call node#initializeCommands()
 
 		let parent = fnamemodify(path, ":h")
 		if parent == path | return | endif


### PR DESCRIPTION
I was enjoying the basic functionality of this but found it frustrating that my own path and suffixadds values were ignored. That means files within my project's 'src' directory may not be found etc. if I'm using this plugin. This set of changes fixes that so that 'normal gf' is the fallback. To make that work cleanly I changed from mapping keys to exporting commands that the user can map as they see fit (I ended up with <leader>o myself). 
