### PR TITLE
Use New Upstream For Node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ tag:
 	git tag "v$(VERSION)"
 
 node.tar.gz:
-	wget -c "https://github.com/joyent/node/archive/master.tar.gz" -O node.tar.gz
+	wget -c "https://github.com/nodejs/node/archive/master.tar.gz" -O node.tar.gz
 
 list-core-modules: node.tar.gz
 	tar tf node.tar.gz |\

--- a/autoload/node/lib.vim
+++ b/autoload/node/lib.vim
@@ -3,7 +3,7 @@ let s:RELPATH = '\v^\.\.?(/|$)'
 let s:MODULE = '\v^(/|\.\.?(/|$))@!'
 
 " Damn Netrw can't handle HTTPS at all. It's 2013! Insecure bastard!
-let s:CORE_URL_PREFIX = "http://rawgit.com/joyent/node"
+let s:CORE_URL_PREFIX = "http://rawgit.com/nodejs/node"
 let s:CORE_MODULES = ["_debugger", "_http_agent", "_http_client",
 	\ "_http_common", "_http_incoming", "_http_outgoing", "_http_server",
 	\ "_linklist", "_stream_duplex", "_stream_passthrough", "_stream_readable",

--- a/test/autoload/lib_test.rb
+++ b/test/autoload/lib_test.rb
@@ -262,7 +262,7 @@ describe "Lib" do
     it "must return URL for core module for current Node version" do
       set_node_version "0.13.37"
       $vim.edit File.join(@dir, "index.js")
-      url = "http://rawgit.com/joyent/node/v0.13.37/lib/assert.js"
+      url = "http://rawgit.com/nodejs/node/v0.13.37/lib/assert.js"
       find("assert").must_equal url
     end
 
@@ -271,14 +271,14 @@ describe "Lib" do
       File.chmod 0755, File.join(@dir, "node")
       $vim.edit File.join(@dir, "index.js")
       $vim.command(%(let $PATH = "#@dir:" . $PATH))
-      url = "http://rawgit.com/joyent/node/master/lib/assert.js"
+      url = "http://rawgit.com/nodejs/node/master/lib/assert.js"
       find("assert").must_equal url
     end
 
     it "must return URL for node.js for current Node version" do
       set_node_version "0.13.37"
       $vim.edit File.join(@dir, "index.js")
-      url = "http://rawgit.com/joyent/node/v0.13.37/src/node.js"
+      url = "http://rawgit.com/nodejs/node/v0.13.37/src/node.js"
       find("node").must_equal url
     end
 
@@ -287,7 +287,7 @@ describe "Lib" do
       File.chmod 0755, File.join(@dir, "node")
       $vim.edit File.join(@dir, "index.js")
       $vim.command(%(let $PATH = "#@dir:" . $PATH))
-      url = "http://rawgit.com/joyent/node/master/src/node.js"
+      url = "http://rawgit.com/nodejs/node/master/src/node.js"
       find("node").must_equal url
     end
   end


### PR DESCRIPTION
Use 'nodejs/node' instead of defunct 'joyent/node' wherever referred to.