### PR TITLE
fix require regex

### DIFF
--- a/autoload/node.vim
+++ b/autoload/node.vim
@@ -29,7 +29,7 @@ function! node#javascript()
 
 	setlocal path-=/usr/include
 	let &l:suffixesadd .= "," . join(g:node#suffixesadd, ",")
-	let &l:include = '\<require(\(["'']\)\zs[^\1]\+\ze\1'
+	let &l:include = '\<require(\(["'']\)\zs[^"'']\+\ze\1'
 	let &l:includeexpr = "node#lib#find(v:fname, bufname('%'))"
 
 	" @ is used for scopes, but isn't a default filename character on


### PR DESCRIPTION
captures aren't usable in collections. would just match `\` and `1`