### PR TITLE
Improve s:resolve to also look in parent directories

### DIFF
--- a/autoload/node/lib.vim
+++ b/autoload/node/lib.vim
@@ -53,7 +53,25 @@ function! s:resolve(path)
 		if !empty(path_with_suffix) | return path_with_suffix | endif
 	endif
 
-	if isdirectory(a:path) | return s:resolveFromDirectory(a:path) | endif
+	if isdirectory(a:path)
+		return s:resolveFromDirectory(a:path)
+	else
+		" If we're looking for a module in node_modules and it can't
+		" be found, Node will also try searching for it in parent
+		" directories.
+		let modulename = fnamemodify(a:path, ":t")
+		let parentname = fnamemodify(a:path, ":h:t")
+		if parentname == "node_modules"
+			let root = fnamemodify(a:path, ":h:h:h")
+			while 1
+				let dir = l:root . "/node_modules/" . l:modulename
+				if isdirectory(l:dir) | return s:resolveFromDirectory(l:dir) | endif
+				let parent = fnamemodify(root, ":h")
+				if l:parent == l:root | break | endif
+				let root = l:parent
+			endwhile
+		endif
+	endif
 endfunction
 
 function! s:resolveFromDirectory(path)

--- a/test/autoload/lib_test.rb
+++ b/test/autoload/lib_test.rb
@@ -194,6 +194,14 @@ describe "Lib" do
       find(".").must_equal target
     end
 
+    it "must return node_modules/foo/index.js given foo in packages/bar/index.js" do
+      target = touch File.join(@dir, "node_modules", "foo", "index.js")
+      touch File.join(@dir, "node_modules", "foo", "package.json"), JSON.dump(:main => "")
+      touch File.join(@dir, "packages", "bar", "package.json")
+      $vim.edit File.join(@dir, "packages", "bar", "index.js")
+      find("foo").must_equal target
+    end
+
     it "must return node_modules/foo/index.js given foo" do
       index = File.join(@dir, "node_modules", "foo", "index.js")
       touch index


### PR DESCRIPTION
Hi there,

I have recently switched one of my Node package to a “monorepo” structure, and noticed “gf” stopped working when trying to open modules contained within the monorepo.

Turned out, `s:resolve` wasn't exactly working like `require()`: in Node.JS, if some package isn't found at a point in path, Node will try all the parent folders, one by one:
https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders

This PR changes `s:resolve` to mimic how Node.JS works, and also adds a test for this case.

Thanks for your hard work!

Cheers,
cwis